### PR TITLE
Include repository URL in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "postinstall": "./bin/local-tld-setup",
     "preuninstall": "./bin/local-tld-uninstall"
   },
-  "repository": "",
+  "repository": "https://github.com/hoodiehq/local-tld",
   "keywords": [
     "tld",
     "pow"


### PR DESCRIPTION
This is used by the npm website to show a link to the repository
