### PR TITLE
Configurable TLDs

### DIFF
--- a/lib/config_file.js
+++ b/lib/config_file.js
@@ -49,15 +49,17 @@ config_file.routes = function() {
   var local_ips = get_local_ips();
   for(var port_m in config) {
     var domain = config[port_m].name;
+    var tld = config[port_m].tld;
+
     routes["localhost"] = "127.0.0.1:80";
-    routes[domain + ".dev"] = "127.0.0.1:" + port_m;
+    routes[domain + "." + tld] = "127.0.0.1:" + port_m;
     local_ips.forEach(function(local_ip) {
       routes[domain + "." + local_ip + ".xip.io"] = "127.0.0.1:" + port_m;
     });
     if(config[port_m].aliases) {
       var aliases = config[port_m].aliases;
       for(var alias in aliases) {
-        routes[".*" + aliases[alias] + "." + domain + ".dev"] = "127.0.0.1:" + port_m;
+        routes[".*" + aliases[alias] + "." + domain + "." + tld] = "127.0.0.1:" + port_m;
         local_ips.forEach(function(local_ip) {
             routes[".*" + aliases[alias] + "." + domain + "." + local_ip + ".xip.io"] = "127.0.0.1:" + port_m;
         });

--- a/lib/config_file.js
+++ b/lib/config_file.js
@@ -49,7 +49,7 @@ config_file.routes = function() {
   var local_ips = get_local_ips();
   for(var port_m in config) {
     var domain = config[port_m].name;
-    var tld = config[port_m].tld;
+    var tld = config[port_m].tld || 'dev';
 
     routes["localhost"] = "127.0.0.1:80";
     routes[domain + "." + tld] = "127.0.0.1:" + port_m;


### PR DESCRIPTION
This pull request adds the ability to set a different TLD for a particular mapping. I was attempting to integrate OAuth2 with a third-party service, but they wouldn't let me register an app with a `.dev` TLD. This is my workaround so that I can have sites served locally from a `.com` TLD.

I personally like being able to set this per-mapping, as opposed to changing the TLD for all domains mapped with local-tld, but I could see adding a configuration option to set the global TLD as well. But that's for another time.
