### PR TITLE
Add support for boot2docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,21 @@ Easy. Just make your configuration look like this:
 
 Now, you should be able to reach `localhost:8000` from `http://myfancyprojectA.dev`, `http://subdomain1.myfancyprojectA.dev`, and `http://subdomain2.myfancyprojectA.dev`!
 
+
+## Sweet. Does it work with boot2docker ports?
+
+Yep! In addition to the port, you'll need to specify your `boot2docker ip` address (usually `192.168.59.103`) for the domains you want to map:
+
+```json
+{
+  "192.168.59.103:8002": {
+    "name": "myfancyprojectC"
+  }
+}
+```
+
+(Astute readers will note that this actually means it works with *any server* on *any IP address*, not just boot2docker)
+
 ## No Original Work
 
 This is all ripped out of `pow`, we don’t claim any credit.

--- a/lib/config_file.js
+++ b/lib/config_file.js
@@ -48,20 +48,23 @@ config_file.routes = function() {
   var routes = {};
   var local_ips = get_local_ips();
   for(var port_m in config) {
+    var host = port_m;
+    if (host.indexOf(':') == -1) {
+      host = "127.0.0.1:" + host;
+    }
     var domain = config[port_m].name;
     var tld = config[port_m].tld || 'dev';
-
     routes["localhost"] = "127.0.0.1:80";
-    routes[domain + "." + tld] = "127.0.0.1:" + port_m;
+    routes[domain + "." + tld] = host;
     local_ips.forEach(function(local_ip) {
-      routes[domain + "." + local_ip + ".xip.io"] = "127.0.0.1:" + port_m;
+      routes[domain + "." + local_ip + ".xip.io"] = host;
     });
     if(config[port_m].aliases) {
       var aliases = config[port_m].aliases;
       for(var alias in aliases) {
-        routes[".*" + aliases[alias] + "." + domain + "." + tld] = "127.0.0.1:" + port_m;
+        routes[".*" + aliases[alias] + "." + domain + "." + tld] = host;
         local_ips.forEach(function(local_ip) {
-            routes[".*" + aliases[alias] + "." + domain + "." + local_ip + ".xip.io"] = "127.0.0.1:" + port_m;
+            routes[".*" + aliases[alias] + "." + domain + "." + local_ip + ".xip.io"] = host;
         });
       }
     }


### PR DESCRIPTION
Basically, allow proxying ports on arbitrary IP addresses, not just 127.0.0.1.
